### PR TITLE
Update CreationSettings.java

### DIFF
--- a/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
+++ b/src/main/java/org/mockito/internal/creation/settings/CreationSettings.java
@@ -57,6 +57,7 @@ public class CreationSettings<T> implements MockCreationSettings<T>, Serializabl
         this.outerClassInstance = copy.getOuterClassInstance();
         this.constructorArgs = copy.getConstructorArgs();
         this.lenient = copy.lenient;
+        this.stripAnnotations = stripAnnotations;
     }
 
     @Override


### PR DESCRIPTION
I was unable to use MockSettings.withoutAnnotations().
stripAnnotation setting had no effect in call to Mockito.mock(class, MockSettins)